### PR TITLE
Fix how to get ApiScopes in ApiResources for ResourceStore

### DIFF
--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.1"
 services:
     identity:
         container_name: identity
-        image: identity:0.1.1-alpha.1
+        image: identity:0.1.1-alpha.2
         build:
             context: ./../
             dockerfile: Docker/${DOCKERFILE}

--- a/Identity.DAL/Repository/Managers/ApiResourceManagercs.cs
+++ b/Identity.DAL/Repository/Managers/ApiResourceManagercs.cs
@@ -22,7 +22,7 @@ namespace Identity.DAL.Repository.Managers
             // As there might be significantly less ApiResources than ApiScopes
             // All ApiResources are queried
             var apiResources = this.AsQueryable().ToList();
-            var apiResourcesIds = apiResources.Select(s => s.Id);
+            var apiResourcesScopesIds = apiResources.SelectMany(s => s.ApiScopeIds);
 
             // But only those ApiScopes in scopeNames are brought
             var apiScopes = this._apiScopeService.FindApiScopesByNames(scopeNames);
@@ -31,7 +31,7 @@ namespace Identity.DAL.Repository.Managers
             return apiResources
                 .Select(apiResource =>
                 {
-                    apiResource.ApiScopes = apiScopes.Where(w => apiResourcesIds.Contains(w.Id)).ToList();
+                    apiResource.ApiScopes = apiScopes.Where(w => apiResourcesScopesIds.Contains(w.Id)).ToList();
                     return apiResource;
                 })
                 .Where(w => w.ApiScopes.Any());
@@ -40,7 +40,7 @@ namespace Identity.DAL.Repository.Managers
         public IEnumerable<ApiResource> FindApiResourcesByNameWithApiScopes(IEnumerable<string> apiResourceNames)
         {
             var apiResources = this.AsQueryable().Where(aR => apiResourceNames.Contains(aR.Name)).ToList();
-            var apiResourcesIds = apiResources.Select(s => s.Id);
+            var apiResourcesScopesIds = apiResources.SelectMany(s => s.ApiScopeIds);
             
             var apiScopesIds = apiResources.Select(s => s.ApiScopeIds).SelectMany(s => s);
             var apiScopes = this._apiScopeService.FindApiScopesByIds(apiScopesIds);
@@ -48,7 +48,7 @@ namespace Identity.DAL.Repository.Managers
             return apiResources
                 .Select(apiResource =>
                 {
-                    apiResource.ApiScopes = apiScopes.Where(w => apiResourcesIds.Contains(w.Id)).ToList();
+                    apiResource.ApiScopes = apiScopes.Where(w => apiResourcesScopesIds.Contains(w.Id)).ToList();
                     return apiResource;
                 })
                 .Where(w => w.ApiScopes.Any());

--- a/Identity/Identity.csproj
+++ b/Identity/Identity.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <AssemblyVersion>0.1.1.1</AssemblyVersion>
+    <AssemblyVersion>0.1.1.2</AssemblyVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Authors>Mario Menjivar</Authors>
     <Description>Identity Server 4 using MongoDB for Stores.</Description>
     <PackageProjectUrl>https://identity.mariomenjr.com/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/mariomenjr/identity</RepositoryUrl>
     <IsPackable>true</IsPackable>
-    <Version>0.1.1-alpha.1</Version>
+    <Version>0.1.1-alpha.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Identity/Startup.cs
+++ b/Identity/Startup.cs
@@ -1,14 +1,13 @@
-using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using System.Reflection;
-using System.Diagnostics;
 using Identity.DAL.Mongo.Extensions;
 using Identity.Stores;
+using Identity.Utils;
 using IdentityServer4.Stores;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.Configuration;
 
 namespace Identity
@@ -49,8 +48,11 @@ namespace Identity
                 endpoints.MapGet("/", async context =>
                 {
                     await context.Response.WriteAsync(
-                        
-                        Utils.About.GetHtmlWelcomePage()
+                        Utils.About.GetHtmlWelcomePage(
+                            env.IsDevelopment()
+                                ? context.Request.GetEncodedUrl()
+                                : About.ProjectUrl
+                        )
                     );
                 });
             });

--- a/Identity/Stores/ResourceStore.cs
+++ b/Identity/Stores/ResourceStore.cs
@@ -14,6 +14,12 @@ namespace Identity.Stores
         private readonly IApiScopeService _apiScopeService;
         private readonly IApiResourceService _apiResourceService;
 
+        private readonly IdentityResource[] _defaultIdentityResources = new IdentityResource[]
+        {
+            new IdentityResources.OpenId(),
+            new IdentityResources.Profile()
+        };
+        
         public ResourceStore(IIdentityResourceService identityResourceService, IApiScopeService apiScopeService,
             IApiResourceService apiResourceService)
         {
@@ -31,12 +37,7 @@ namespace Identity.Stores
                 .Select(iR => new IdentityResource {Name = iR.Name});
 
             // Hardcoded
-            return await Task.Run(() => new IdentityResource[]
-                {
-                    new IdentityResources.OpenId(),
-                    new IdentityResources.Profile()
-                }
-                .Union(foundIdentityResources));
+            return await Task.Run(() => this._defaultIdentityResources.Union(foundIdentityResources));
         }
 
         public async Task<IEnumerable<ApiScope>> FindApiScopesByNameAsync(IEnumerable<string> scopeNames)
@@ -84,16 +85,11 @@ namespace Identity.Stores
         {
             return await Task.Run(() => new Resources()
             {
-                ApiScopes = this._apiScopeService.Find().Select(s => new ApiScope()
-                {
-                    Name = s.Name,
-                    DisplayName = s.DisplayName
-                }).ToList(),
-
-                IdentityResources = this._identityResourceService.Find().Select(s => new IdentityResource()
-                {
-                    Name = s.Name
-                }).ToList()
+                ApiScopes = this._apiScopeService.Find().Select(s => new ApiScope() {Name = s.Name}).ToList(),
+                ApiResources = this._apiResourceService.Find().Select(s => new ApiResource {Name = s.Name}).ToList(),
+                IdentityResources = this._defaultIdentityResources
+                    .Union(this._identityResourceService.Find().Select(s => new IdentityResource() {Name = s.Name}))
+                    .ToList()
             });
         }
     }

--- a/Identity/Utils/About.cs
+++ b/Identity/Utils/About.cs
@@ -7,17 +7,22 @@ namespace Identity.Utils
 {
     public static class About
     {
-        public static string GetHtmlWelcomePage()
+        public const string ProjectUrl = "https://identity.mariomenjr.com/";
+
+        public static string GetHtmlWelcomePage(string hostName)
         {
             var body = string.Join(
                 "<br />",
                 new string[]
                 {
                     $"{DateTimeOffset.Now.ToString()}/{IdentityInfo.Configuration}",
-                    "<br />",
+                    string.Empty,
                     $"{IdentityInfo.Product}@v{IdentityInfo.InformationalVersion}",
                     $" {IdentityInfo.Description}",
                     $"<a href=\"{IdentityInfo.RepositoryUrl}\">{IdentityInfo.RepositoryUrl}</a>",
+                    string.Empty, 
+                    "Discovery document",
+                    $"<a href=\"{hostName}.well-known/openid-configuration\">{hostName}.well-known/openid-configuration</a>"
                 }
             );
             


### PR DESCRIPTION
Problem:

A token was generated. But could not be validated for authentication. Error shown: `UnauthorizedError: jwt audience invalid. expected:`.

Explanation:

No ApiScope was getting linked to the ApiResources in the IResourceStore implementation due to a filter error in two ApiResourceManager methods.

Solution:

Correct the filtering process to get each ApiResource's ApiScopes Ids.

Additionally:

- Enhancements to Welcome Page and the Discovery Document